### PR TITLE
Transition display fixes & a bug fix

### DIFF
--- a/Assets/Scripts/Field/FMS.cs
+++ b/Assets/Scripts/Field/FMS.cs
@@ -41,46 +41,48 @@ public class FMS : MonoBehaviour
         robotState = RobotState;
         if (robotState == RobotState.enabled) MatchTimer -= Time.deltaTime;
 
-        if (MatchTimer >= matchTime - autoTime)
+        // Determine the current state strictly from MatchTimer, in order.
+        MatchState newState;
+        if (MatchTimer < 0)
         {
-            MatchState = MatchState.auto;
-        }  else if (MatchTimer >= endgameTime)
-        {
-            MatchState = MatchState.teleop;
+            newState = MatchState.finished;
         }
-        else if (MatchTimer < 0)
+        else if (MatchTimer <= endgameTime)
         {
-            MatchState = MatchState.finished;
-        } else if (MatchTimer <= endgameTime)
+            newState = MatchState.endgame;
+        }
+        else if (MatchTimer >= matchTime - autoTime)
         {
-            MatchState = MatchState.endgame;
+            newState = MatchState.auto;
+        }
+        else
+        {
+            newState = MatchState.teleop;
         }
 
-        if (MatchState != previousMatchState && MatchState != MatchState.endgame)
+        // Only react on an actual transition — no self-retriggering.
+        if (newState != previousMatchState)
         {
-            switch (MatchState)
+            switch (newState)
             {
                 case MatchState.teleop:
-                    MatchState = MatchState.auto;
+                    // Brief disable between auto and teleop.
                     StartCoroutine(wait(autoDisableTime));
-                    MatchState = MatchState.teleop;
                     break;
                 case MatchState.finished:
-                    MatchState = MatchState.endgame;
+                    // Brief disable at match end.
                     StartCoroutine(wait(matchDisabledTime));
-                    MatchState = MatchState.finished;
                     break;
             }
         }
 
-        previousMatchState = MatchState;
+        MatchState = newState;
+        previousMatchState = newState;
 
-        float minutes = Mathf.FloorToInt(MatchTimer / 60);
-
-        float seconds = Mathf.FloorToInt(MatchTimer % 60);
-
-        if (minutes < 0) minutes = 0;
-        if (seconds < 0) seconds = 0;
+        // Use CeilToInt so the displayed value equals the time REMAINING
+        int totalSeconds = Mathf.CeilToInt(Mathf.Max(MatchTimer, 0f));
+        int minutes = totalSeconds / 60;
+        int seconds = totalSeconds % 60;
 
         if (timer != null)
         {

--- a/Assets/Scripts/Field/FMS.cs
+++ b/Assets/Scripts/Field/FMS.cs
@@ -41,7 +41,6 @@ public class FMS : MonoBehaviour
         robotState = RobotState;
         if (robotState == RobotState.enabled) MatchTimer -= Time.deltaTime;
 
-        // Determine the current state strictly from MatchTimer, in order.
         MatchState newState;
         if (MatchTimer < 0)
         {
@@ -60,17 +59,14 @@ public class FMS : MonoBehaviour
             newState = MatchState.teleop;
         }
 
-        // Only react on an actual transition — no self-retriggering.
         if (newState != previousMatchState)
         {
             switch (newState)
             {
                 case MatchState.teleop:
-                    // Brief disable between auto and teleop.
                     StartCoroutine(wait(autoDisableTime));
                     break;
                 case MatchState.finished:
-                    // Brief disable at match end.
                     StartCoroutine(wait(matchDisabledTime));
                     break;
             }
@@ -79,7 +75,6 @@ public class FMS : MonoBehaviour
         MatchState = newState;
         previousMatchState = newState;
 
-        // Use CeilToInt so the displayed value equals the time REMAINING
         int totalSeconds = Mathf.CeilToInt(Mathf.Max(MatchTimer, 0f));
         int minutes = totalSeconds / 60;
         int seconds = totalSeconds % 60;

--- a/Assets/Scripts/Field/SeasonSpecific/RebuiltShifts.cs
+++ b/Assets/Scripts/Field/SeasonSpecific/RebuiltShifts.cs
@@ -14,6 +14,25 @@ public class RebuiltShifts : ScoreOnlyOnce
     private MatchState previousMatchState;
 
     [SerializeField] private GameObject shiftOnLight;
+
+    // Season-specific match timing
+    [Header("Season Match Timing")]
+    [SerializeField] private int seasonMatchTime = 160;
+    [SerializeField] private int seasonAutoTime = 20;
+    [SerializeField] private int seasonEndgameTime = 30;
+
+    private void Awake()
+    {
+        // Push this season's timing into the (season-generic) FMS before it initializes
+        var fms = FindObjectOfType<FMS>();
+        if (fms != null)
+        {
+            fms.matchTime = seasonMatchTime;
+            fms.autoTime = seasonAutoTime;
+            fms.endgameTime = seasonEndgameTime;
+        }
+    }
+
     // Update is called once per frame
     private void Start()
     {
@@ -22,20 +41,17 @@ public class RebuiltShifts : ScoreOnlyOnce
         teleopStartMatchTimer = 0f;
         currentShift = CurrentShift.Auto;
         previousMatchState = MatchState.auto;
+        FMS.MatchTimer = seasonMatchTime;
     }
 
     private new void FixedUpdate()
     {
         shiftOnLight.SetActive(isOnShift());
-
         poolOccupyObjects();
-
         handleShiftState();
         // Create a set of current objects for comparison
         compareObjects(isOnShift());
-
         ScorePoints(totalScore); // Pass the total accumulated score
-
         ShiftOverlay.ShiftTimer = shiftTimer;
         switch (currentShift)
         {
@@ -67,9 +83,10 @@ public class RebuiltShifts : ScoreOnlyOnce
 
         if (FMS.MatchState is not MatchState.auto)
         {
+            // Teleop elapsed == how far FMS.MatchTimer has moved since teleop started. This pauses automatically whenever FMS.MatchTimer is paused
             float teleopElapsed = teleopStartMatchTimer - FMS.MatchTimer;
             if (teleopElapsed < 0f) teleopElapsed = 0f;
-
+            
             CurrentShift resolved;
             float remaining;
             if (teleopElapsed < TransitionEnd)
@@ -100,11 +117,14 @@ public class RebuiltShifts : ScoreOnlyOnce
             else
             {
                 resolved = CurrentShift.EndGame;
+                // End game runs until the match ends
                 remaining = Mathf.Max(FMS.MatchTimer, 0f);
             }
+
             currentShift = resolved;
             shiftTimer = remaining;
         }
+
         previousMatchState = FMS.MatchState;
     }
 
@@ -134,7 +154,7 @@ public class RebuiltShifts : ScoreOnlyOnce
             }
         }
     }
-    
+
     [Serializable]
     public enum CurrentShift
     {

--- a/Assets/Scripts/Field/SeasonSpecific/RebuiltShifts.cs
+++ b/Assets/Scripts/Field/SeasonSpecific/RebuiltShifts.cs
@@ -23,7 +23,6 @@ public class RebuiltShifts : ScoreOnlyOnce
 
     private void Awake()
     {
-        // Push this season's timing into the (season-generic) FMS before it initializes
         var fms = FindObjectOfType<FMS>();
         if (fms != null)
         {
@@ -49,9 +48,8 @@ public class RebuiltShifts : ScoreOnlyOnce
         shiftOnLight.SetActive(isOnShift());
         poolOccupyObjects();
         handleShiftState();
-        // Create a set of current objects for comparison
         compareObjects(isOnShift());
-        ScorePoints(totalScore); // Pass the total accumulated score
+        ScorePoints(totalScore);
         ShiftOverlay.ShiftTimer = shiftTimer;
         switch (currentShift)
         {
@@ -83,7 +81,6 @@ public class RebuiltShifts : ScoreOnlyOnce
 
         if (FMS.MatchState is not MatchState.auto)
         {
-            // Teleop elapsed == how far FMS.MatchTimer has moved since teleop started. This pauses automatically whenever FMS.MatchTimer is paused
             float teleopElapsed = teleopStartMatchTimer - FMS.MatchTimer;
             if (teleopElapsed < 0f) teleopElapsed = 0f;
             

--- a/Assets/Scripts/Field/SeasonSpecific/RebuiltShifts.cs
+++ b/Assets/Scripts/Field/SeasonSpecific/RebuiltShifts.cs
@@ -10,6 +10,7 @@ public class RebuiltShifts : ScoreOnlyOnce
     public static CurrentShift currentShift;
     private bool blueWonAuto;
     private float shiftTimer;
+    private float teleopStartMatchTimer;
     private MatchState previousMatchState;
 
     [SerializeField] private GameObject shiftOnLight;
@@ -17,8 +18,10 @@ public class RebuiltShifts : ScoreOnlyOnce
     private void Start()
     {
         blueWonAuto = false;
-        shiftTimer = 3;
+        shiftTimer = 0;
+        teleopStartMatchTimer = 0f;
         currentShift = CurrentShift.Auto;
+        previousMatchState = MatchState.auto;
     }
 
     private new void FixedUpdate()
@@ -37,55 +40,77 @@ public class RebuiltShifts : ScoreOnlyOnce
         switch (currentShift)
         {
             case CurrentShift.Auto:       ShiftOverlay.ShiftName = "Auto"; break;
-            case CurrentShift.Transition:  ShiftOverlay.ShiftName = "1/6"; break;
-            case CurrentShift.Shift1:      ShiftOverlay.ShiftName = "2/6"; break;
-            case CurrentShift.Shift2:      ShiftOverlay.ShiftName = "3/6"; break;
-            case CurrentShift.Shift3:      ShiftOverlay.ShiftName = "4/6"; break;
-            case CurrentShift.Shift4:      ShiftOverlay.ShiftName = "5/6"; break;
-            case CurrentShift.EndGame:     ShiftOverlay.ShiftName = "6/6"; break;
-            default:                       ShiftOverlay.ShiftName = ""; break;
+            case CurrentShift.Transition: ShiftOverlay.ShiftName = "1/6"; break;
+            case CurrentShift.Shift1:     ShiftOverlay.ShiftName = "2/6"; break;
+            case CurrentShift.Shift2:     ShiftOverlay.ShiftName = "3/6"; break;
+            case CurrentShift.Shift3:     ShiftOverlay.ShiftName = "4/6"; break;
+            case CurrentShift.Shift4:     ShiftOverlay.ShiftName = "5/6"; break;
+            case CurrentShift.EndGame:    ShiftOverlay.ShiftName = "6/6"; break;
+            default:                      ShiftOverlay.ShiftName = ""; break;
         }
     }
+    private const float TransitionEnd = 10f;
+    private const float Shift1End     = 35f;
+    private const float Shift2End     = 60f;
+    private const float Shift3End     = 85f;
+    private const float Shift4End     = 110f;
 
     private void handleShiftState()
     {
         if (FMS.MatchState != MatchState.auto && previousMatchState == MatchState.auto)
         {
-            if (ScoreHolder.BlueScore > ScoreHolder.RedScore)
-            {
-                blueWonAuto = true;
-            }else if (ScoreHolder.BlueScore == ScoreHolder.RedScore)
-            {
-                var rng = new Random();
-                blueWonAuto = rng.Next(0, 1) == 1;
-            }
-
-            currentShift = CurrentShift.Auto;
+            blueWonAuto = ScoreHolder.BlueScore > ScoreHolder.RedScore;
+            teleopStartMatchTimer = FMS.MatchTimer;
+            currentShift = CurrentShift.Transition;
+            shiftTimer = TransitionEnd;
         }
 
         if (FMS.MatchState is not MatchState.auto)
         {
-            shiftTimer -= Time.deltaTime;
+            float teleopElapsed = teleopStartMatchTimer - FMS.MatchTimer;
+            if (teleopElapsed < 0f) teleopElapsed = 0f;
 
-            if (shiftTimer <= 0 && currentShift != CurrentShift.EndGame)
+            CurrentShift resolved;
+            float remaining;
+            if (teleopElapsed < TransitionEnd)
             {
-                if (currentShift == CurrentShift.Auto)
-                    shiftTimer = 10;
-                else if (currentShift == CurrentShift.Shift4)
-                    shiftTimer = 30;
-                else
-                    shiftTimer = 25;
-                currentShift += 1;
+                resolved = CurrentShift.Transition;
+                remaining = TransitionEnd - teleopElapsed;
             }
+            else if (teleopElapsed < Shift1End)
+            {
+                resolved = CurrentShift.Shift1;
+                remaining = Shift1End - teleopElapsed;
+            }
+            else if (teleopElapsed < Shift2End)
+            {
+                resolved = CurrentShift.Shift2;
+                remaining = Shift2End - teleopElapsed;
+            }
+            else if (teleopElapsed < Shift3End)
+            {
+                resolved = CurrentShift.Shift3;
+                remaining = Shift3End - teleopElapsed;
+            }
+            else if (teleopElapsed < Shift4End)
+            {
+                resolved = CurrentShift.Shift4;
+                remaining = Shift4End - teleopElapsed;
+            }
+            else
+            {
+                resolved = CurrentShift.EndGame;
+                remaining = Mathf.Max(FMS.MatchTimer, 0f);
+            }
+            currentShift = resolved;
+            shiftTimer = remaining;
         }
-
         previousMatchState = FMS.MatchState;
     }
 
     private bool isOnShift()
     {
         var isBlue = GetIsBlue();
-
         if (blueWonAuto)
         {
             if (isBlue)
@@ -96,7 +121,6 @@ public class RebuiltShifts : ScoreOnlyOnce
             {
                 return currentShift is CurrentShift.Auto or CurrentShift.Transition or CurrentShift.Shift1 or CurrentShift.Shift3 or CurrentShift.EndGame;
             }
-
         }
         else
         {
@@ -110,7 +134,7 @@ public class RebuiltShifts : ScoreOnlyOnce
             }
         }
     }
-
+    
     [Serializable]
     public enum CurrentShift
     {


### PR DESCRIPTION
Issues Fixed with FMS/Shifts Display

1. The main match clock was off by 1 second at the start and at the auto-to-transition.
2. The shift clock and the main clock could drift apart
3. Shifts could skip past a boundary (like jumping from 1/6 to 3/6).

To Note:

- Branched off Experimental like you said.
- FMS.cs defaultsl 150/15/20 so it stays season-generic. (I made sure)

Everything changed works, should be no more bugs.